### PR TITLE
Remove the automatically change: dictionary_args['use_chains'] = True…

### DIFF
--- a/python/csm/input_output/arguments.py
+++ b/python/csm/input_output/arguments.py
@@ -346,7 +346,7 @@ def _process_arguments(parse_res):
                     if dictionary_args['chain_perm_file_name']:
                         raise ValueError("error: argument --many-chains not allowed with argument --input-chain-perm")
 
-                if parse_res.use_backbone or parse_res.chain_perm_file_name:
+                if parse_res.chain_perm_file_name:
                     dictionary_args['use_chains'] = True
 
                 if parse_res.selective is not None:
@@ -362,7 +362,7 @@ def _process_arguments(parse_res):
                     # outputs:
 
             if parse_res.command == 'trivial':
-                if parse_res.permute_chains or parse_res.chain_perm_file_name or parse_res.use_backbone:
+                if parse_res.permute_chains or parse_res.chain_perm_file_name:
                     dictionary_args["use_chains"] = True
 
     try:


### PR DESCRIPTION
ענבל:

בדוגמה של יפה יש מונומר שרוצים לחשב את הכירליות שלו בהתעלם משיירי הצד. אז לא צריך את use-chains.
לא הייתי קושרת בין שני הדגלים. משתמש יוסיף use-chains  כשיהיה צורך.

כל  הטסטים עוברים.